### PR TITLE
Strictly specify the ID timestamp property of posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ This is my first post on Org-social.
 
 The header `**` indicates a new post. The `:PROPERTIES:` drawer is used to add metadata to the post, such as the unique identifier (`ID`) and other optional properties.
 
-The datetime in the `ID` property is the unique identifier of each post. It must be in *ISO 8601 format*. The time zone, `+01:00`, isn't optional.
+The datetime in the `ID` property is the unique identifier of each post. It must be in a subset of the *RFC 3339 format*. matching any of the forms:
+
+* `####-##-##T##:##:##+##:##` e.g. `2025-12-30T20:30:15+00:00`, `2025-12-30T22:30:15+02:00`
+* `####-##-##T##:##:##-##:##` (not including an offset of `00:00`) e.g. `2025-12-30T18:30:15-02:00`
 
 The result will be:
 


### PR DESCRIPTION
The chosen subset of RFC 3339 is supported by both ISO 8601 and RFC 3339 compliant parsers, so should be widely and unambiguously parsable.

RFC 3339 being the main reference also allows it to be more accessible to those unable to pay to see the ISO 8601 specification