### PR TITLE
Post's TITLE property

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Each post uses Org Mode's properties drawer for metadata:
 **
 :PROPERTIES:
 :ID: 2025-05-01T12:00:00+0100
+:TITLE: A post with metadata
 :LANG: en
 :TAGS: programming social
 :CLIENT: org-social.el
@@ -202,6 +203,7 @@ Available properties:
 | Property | Description |
 |----------|-------------|
 | `ID` | Unique timestamp identifier (required) |
+| `TITLE` | A post's title/short summary |
 | `LANG` | Language code of the post |
 | `TAGS` | Space-separated tags |
 | `CLIENT` | Client application used |


### PR DESCRIPTION
Posts having an optional `:TITLE:` property is a great feature I thought the spec lacked - noone uses it.
It seems like a great feature for implementing better clients. 
The ability to summarize a post in a short, single line improves readability for whenever the client wants to display a post's identifier that's more memorable and readable than an ID.
Currently, for the rust client, I had to dumbly truncate the content for such uses, but that is not really a readable option.

And to discover that the spec technically has the property I wanted to suggest, as it was already mentioned later (in the RSS/Atom replacement section).
Of course providing titles shouldn't be a requirement, but I think it should definitely be an advertised feature.